### PR TITLE
refactor: extract base inline styles to main.css

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ curl http://127.0.0.1:5000/contact
 ```
 
 - **엔드포인트**: `/` (홈 리다이렉트), `/home`, `/projects`, `/contact`
-- **구조**: `wsgi.py`(권장 진입), `app.py`(Lab 호환 래퍼), `app/` 패키지, `app/bootstrap.py`에서 Blueprint 등록, 연락처 표시 규칙은 `app/contact_display.py`, 기능별 `app/blueprints/`
+- **구조**: `wsgi.py`(권장 진입), `app.py`(Lab 호환 래퍼), `app/` 패키지, `app/bootstrap.py`에서 Blueprint 등록, 연락처 표시 규칙은 `app/contact_display.py`, 공통 스타일은 `app/static/css/main.css`, 기능별 `app/blueprints/`
 - **콘텐츠 데이터**: 프로젝트·연락처 목록은 `app/data/projects.json`, `app/data/contact.json`에서 읽는다 (`app/site_data.py`). 비속어 마스킹 단어 목록은 `app/data/profanity_words.json` (`mask_profanity`).
 
 ---

--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -1,0 +1,73 @@
+:root {
+    --bg: #0f0f12;
+    --surface: #1a1a1f;
+    --text: #e8e8ed;
+    --muted: #8b8b9a;
+    --accent: #6366f1;
+    --accent-hover: #818cf8;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body {
+    font-family: 'Segoe UI', system-ui, sans-serif;
+    background: var(--bg);
+    color: var(--text);
+    margin: 0;
+    min-height: 100vh;
+    line-height: 1.6;
+}
+
+nav {
+    background: var(--surface);
+    padding: 1rem 2rem;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+nav a {
+    color: var(--muted);
+    text-decoration: none;
+    margin-right: 1.5rem;
+}
+
+nav a:hover {
+    color: var(--accent);
+}
+
+main {
+    max-width: 720px;
+    margin: 0 auto;
+    padding: 2rem;
+}
+
+h1 {
+    font-size: 1.75rem;
+    margin-top: 0;
+}
+
+a {
+    color: var(--accent);
+}
+
+a:hover {
+    color: var(--accent-hover);
+}
+
+.card {
+    background: var(--surface);
+    border-radius: 8px;
+    padding: 1.25rem 1.5rem;
+    margin-bottom: 1rem;
+}
+
+.tag {
+    display: inline-block;
+    background: rgba(99, 102, 241, 0.2);
+    color: var(--accent);
+    padding: 0.2rem 0.5rem;
+    border-radius: 4px;
+    font-size: 0.85rem;
+    margin-right: 0.25rem;
+}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -4,47 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{% block title %}Dev-Log{% endblock %} | 개인 포트폴리오</title>
-    <style>
-        :root {
-            --bg: #0f0f12;
-            --surface: #1a1a1f;
-            --text: #e8e8ed;
-            --muted: #8b8b9a;
-            --accent: #6366f1;
-            --accent-hover: #818cf8;
-        }
-        * { box-sizing: border-box; }
-        body {
-            font-family: 'Segoe UI', system-ui, sans-serif;
-            background: var(--bg);
-            color: var(--text);
-            margin: 0;
-            min-height: 100vh;
-            line-height: 1.6;
-        }
-        nav {
-            background: var(--surface);
-            padding: 1rem 2rem;
-            border-bottom: 1px solid rgba(255,255,255,0.06);
-        }
-        nav a {
-            color: var(--muted);
-            text-decoration: none;
-            margin-right: 1.5rem;
-        }
-        nav a:hover { color: var(--accent); }
-        main { max-width: 720px; margin: 0 auto; padding: 2rem; }
-        h1 { font-size: 1.75rem; margin-top: 0; }
-        a { color: var(--accent); }
-        a:hover { color: var(--accent-hover); }
-        .card {
-            background: var(--surface);
-            border-radius: 8px;
-            padding: 1.25rem 1.5rem;
-            margin-bottom: 1rem;
-        }
-        .tag { display: inline-block; background: rgba(99,102,241,0.2); color: var(--accent); padding: 0.2rem 0.5rem; border-radius: 4px; font-size: 0.85rem; margin-right: 0.25rem; }
-    </style>
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/main.css') }}">
 </head>
 <body>
     <nav>


### PR DESCRIPTION
## 요약
`base.html`의 `<style>` 블록을 `app/static/css/main.css`로 옮기고, `<head>`에서 `url_for('static', filename='css/main.css')`로 로드합니다.

## 변경 사항
- **추가**: `app/static/css/main.css` — 기존 인라인 규칙과 동일한 전역 스타일
- **수정**: `app/templates/base.html` — 인라인 스타일 제거, 외부 시트 링크
- **문서**: `README.md` — 공통 스타일 경로(`app/static/css/main.css`) 한 줄 안내

## 이유
- HTML과 스타일 분리로 유지보수·캐싱에 유리
- 코드 스멜(긴 인라인 CSS) 완화

## 확인
- [x] `pytest` (11 tests) 통과